### PR TITLE
Rename serverless handlers per convention

### DIFF
--- a/src/__tests__/integrationV1.test.ts
+++ b/src/__tests__/integrationV1.test.ts
@@ -5,7 +5,7 @@ import {
 } from '@apollo/server-integration-testsuite';
 import type { Handler } from 'aws-lambda';
 import { createServer } from 'http';
-import { startAndCreateLambdaHandler } from '..';
+import { startServerAndCreateLambdaHandler } from '..';
 import { createMockV1Server } from './mockAPIGatewayV1Server';
 import { urlForHttpServer } from './mockServer';
 
@@ -21,8 +21,8 @@ describe('lambdaHandlerV1', () => {
       });
 
       const handler: Handler = testOptions
-        ? startAndCreateLambdaHandler(server, testOptions)
-        : startAndCreateLambdaHandler(server);
+        ? startServerAndCreateLambdaHandler(server, testOptions)
+        : startServerAndCreateLambdaHandler(server);
 
       httpServer.addListener('request', createMockV1Server(handler));
 

--- a/src/__tests__/integrationV1.test.ts
+++ b/src/__tests__/integrationV1.test.ts
@@ -5,7 +5,7 @@ import {
 } from '@apollo/server-integration-testsuite';
 import type { Handler } from 'aws-lambda';
 import { createServer } from 'http';
-import { lambdaHandler } from '..';
+import { startAndCreateLambdaHandler } from '..';
 import { createMockV1Server } from './mockAPIGatewayV1Server';
 import { urlForHttpServer } from './mockServer';
 
@@ -21,8 +21,8 @@ describe('lambdaHandlerV1', () => {
       });
 
       const handler: Handler = testOptions
-        ? lambdaHandler(server, testOptions)
-        : lambdaHandler(server);
+        ? startAndCreateLambdaHandler(server, testOptions)
+        : startAndCreateLambdaHandler(server);
 
       httpServer.addListener('request', createMockV1Server(handler));
 

--- a/src/__tests__/integrationV2.test.ts
+++ b/src/__tests__/integrationV2.test.ts
@@ -4,7 +4,7 @@ import {
   defineIntegrationTestSuite,
 } from '@apollo/server-integration-testsuite';
 import { createServer } from 'http';
-import { lambdaHandler } from '..';
+import { startAndCreateLambdaHandler } from '..';
 import { createMockV2Server } from './mockAPIGatewayV2Server';
 import { urlForHttpServer } from './mockServer';
 
@@ -20,8 +20,8 @@ describe('lambdaHandlerV2', () => {
       });
 
       const handler = testOptions
-        ? lambdaHandler(server, testOptions)
-        : lambdaHandler(server);
+        ? startAndCreateLambdaHandler(server, testOptions)
+        : startAndCreateLambdaHandler(server);
 
       httpServer.addListener('request', createMockV2Server(handler));
 

--- a/src/__tests__/integrationV2.test.ts
+++ b/src/__tests__/integrationV2.test.ts
@@ -4,7 +4,7 @@ import {
   defineIntegrationTestSuite,
 } from '@apollo/server-integration-testsuite';
 import { createServer } from 'http';
-import { startAndCreateLambdaHandler } from '..';
+import { startServerAndCreateLambdaHandler } from '..';
 import { createMockV2Server } from './mockAPIGatewayV2Server';
 import { urlForHttpServer } from './mockServer';
 
@@ -20,8 +20,8 @@ describe('lambdaHandlerV2', () => {
       });
 
       const handler = testOptions
-        ? startAndCreateLambdaHandler(server, testOptions)
-        : startAndCreateLambdaHandler(server);
+        ? startServerAndCreateLambdaHandler(server, testOptions)
+        : startServerAndCreateLambdaHandler(server);
 
       httpServer.addListener('request', createMockV2Server(handler));
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -32,15 +32,15 @@ type LambdaHandler = Handler<
   APIGatewayProxyStructuredResultV2 | APIGatewayProxyResult
 >;
 
-export function lambdaHandler(
+export function startAndCreateLambdaHandler(
   server: ApolloServer<BaseContext>,
   options?: LambdaHandlerOptions<BaseContext>,
 ): LambdaHandler;
-export function lambdaHandler<TContext extends BaseContext>(
+export function startAndCreateLambdaHandler<TContext extends BaseContext>(
   server: ApolloServer<TContext>,
   options: WithRequired<LambdaHandlerOptions<TContext>, 'context'>,
 ): LambdaHandler;
-export function lambdaHandler<TContext extends BaseContext>(
+export function startAndCreateLambdaHandler<TContext extends BaseContext>(
   server: ApolloServer<TContext>,
   options?: LambdaHandlerOptions<TContext>,
 ): LambdaHandler {

--- a/src/index.ts
+++ b/src/index.ts
@@ -32,15 +32,15 @@ type LambdaHandler = Handler<
   APIGatewayProxyStructuredResultV2 | APIGatewayProxyResult
 >;
 
-export function startAndCreateLambdaHandler(
+export function startServerAndCreateLambdaHandler(
   server: ApolloServer<BaseContext>,
   options?: LambdaHandlerOptions<BaseContext>,
 ): LambdaHandler;
-export function startAndCreateLambdaHandler<TContext extends BaseContext>(
+export function startServerAndCreateLambdaHandler<TContext extends BaseContext>(
   server: ApolloServer<TContext>,
   options: WithRequired<LambdaHandlerOptions<TContext>, 'context'>,
 ): LambdaHandler;
-export function startAndCreateLambdaHandler<TContext extends BaseContext>(
+export function startServerAndCreateLambdaHandler<TContext extends BaseContext>(
   server: ApolloServer<TContext>,
   options?: LambdaHandlerOptions<TContext>,
 ): LambdaHandler {


### PR DESCRIPTION
We want to adopt a convention of naming serverless integrations prependended with "start" so that it's clear the function will handle calling `ApolloServer.start()` for the user, as opposed to non-serverless integrations where we expect the user to call `.start()` before handing off the server instance to the handler creator.

Ref: https://github.com/apollographql/apollo-server/pull/6922